### PR TITLE
docs: add README badges, example output section, and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to ccplugin-ai-review
+
+Thank you for your interest in contributing!
+
+## This Plugin is Markdown-Only
+
+There is no build step, no compiled code, and no test runner. All plugin logic lives in:
+
+- `commands/ai-review.md` — Claude Code command definition
+- `skills/ai-review/SKILL.md` — Skill trigger and setup docs
+- `.github/workflows/ai-review.yml` — GitHub Actions workflow
+- `.claude-plugin/plugin.json` — Plugin metadata
+
+## How to Contribute
+
+### 1. Fork and clone
+
+```bash
+git clone https://github.com/<your-username>/ccplugin-ai-review.git
+cd ccplugin-ai-review
+```
+
+### 2. Create a branch
+
+Use a descriptive branch name:
+
+```bash
+git checkout -b fix/handle-empty-diff
+git checkout -b feat/add-model-option
+git checkout -b docs/improve-setup-guide
+```
+
+### 3. Make your changes
+
+Edit the relevant markdown or YAML files. Keep changes focused and minimal.
+
+### 4. Commit
+
+Use conventional commits:
+
+```
+feat: add support for specifying model via argument
+fix: handle empty diff gracefully
+docs: clarify API key setup instructions
+chore: update .gitignore
+```
+
+### 5. Open a Pull Request
+
+Push your branch and open a PR against `main`. Describe:
+- What problem you are solving
+- What you changed
+- How to verify the change works
+
+## Guidelines
+
+- Keep PRs small and focused
+- Update CHANGELOG.md under `[Unreleased]` for user-visible changes
+- Do not commit secrets or API keys
+- YAML workflows must be valid (check with `python3 -c "import yaml; yaml.safe_load(open('file.yml'))"`)
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # ai-review — Claude Code Plugin
 
+[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](CHANGELOG.md)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Cost](https://img.shields.io/badge/cost-%240-brightgreen.svg)](https://openrouter.ai)
+[![OpenRouter](https://img.shields.io/badge/powered%20by-OpenRouter-purple.svg)](https://openrouter.ai)
+
 by [Musab Kara](https://linkedin.com/in/musab-kara-85580612a) · [GitHub](https://github.com/SkyWalker2506)
 
-Automated GitHub PR review via OpenRouter free models (Gemma 3 27B). Posts AI-generated review comments on pull requests. $0 cost.
+Automated GitHub PR review via OpenRouter free models (Gemma 3 27B + Mistral 7B fallback). Posts AI-generated review comments on pull requests. $0 cost.
 
 ## Install
 
@@ -30,8 +35,41 @@ Add to `~/.claude/secrets/secrets.env`:
 OPENROUTER_API_KEY=<from openrouter.ai>
 ```
 
+Then add the workflow from `.github/workflows/ai-review.yml` (included in this repo) to any repo you want auto-reviewed on every PR.
+
+## Example Output
+
+When a PR is opened, the bot posts a comment like this:
+
+---
+
+**🤖 AI Code Review**
+
+## Summary
+This PR adds rate limiting middleware to the Express API. It introduces the `express-rate-limit` package and applies a 100 req/min limit to all `/api/*` routes.
+
+## Issues
+- **Line 23**: The rate limit window is set to `60 * 1000` ms but the comment says "1 hour" — this is 1 minute. Update the comment or the value.
+- **Line 41**: `store` is not configured; defaults to in-memory, which resets on server restart. For production, use Redis store.
+
+## Suggestions
+- Consider applying stricter limits to `/api/auth/*` endpoints (e.g. 10 req/min) to protect against brute force.
+- Add a `X-RateLimit-*` header response so clients know their quota.
+
+---
+_Powered by [ccplugin-ai-review](https://github.com/SkyWalker2506/ccplugin-ai-review) · Free via OpenRouter_
+
+---
+
+## Models
+
+| Role | Model | Notes |
+|------|-------|-------|
+| Primary | `google/gemma-3-27b-it:free` | Best quality |
+| Fallback | `mistralai/mistral-7b-instruct:free` | Used if primary at capacity |
+
 ## Part of
 
-- [claude-config](https://github.com/SkyWalker2506/claude-config) — Multi-Agent OS for Claude Code (134 agents, local-first routing)
-- [Plugin Marketplace](https://github.com/SkyWalker2506/claude-marketplace) — Browse & install all 18 plugins
+- [claude-config](https://github.com/SkyWalker2506/claude-config) — Multi-Agent OS for Claude Code
+- [Plugin Marketplace](https://github.com/SkyWalker2506/claude-marketplace) — Browse & install all plugins
 - [ClaudeHQ](https://github.com/SkyWalker2506/ClaudeHQ) — Claude ecosystem HQ


### PR DESCRIPTION
Adds 4 shield.io badges to README (version, license, cost, OpenRouter). Adds realistic example review output block. Adds CONTRIBUTING.md with fork/PR workflow, commit conventions, and guidelines. Closes #8 #9 #10